### PR TITLE
경고음 관련

### DIFF
--- a/Desummer/Scripts/DonutControl.cs
+++ b/Desummer/Scripts/DonutControl.cs
@@ -24,7 +24,7 @@ namespace Desummer.Scripts
 
         Graph graph;
         MediaPlayer MP3 = new MediaPlayer();
-        Uri uri = new Uri("C:\\Users\\o\\Downloads\\DeSummer\\Desummer\\Resources\\alarm.mp3");
+        Uri uri = new Uri("c:/Windows/Media/Windows Critical Stop.wav");
 
         public PlotControl(WpfPlot temperatureDonut1, WpfPlot temperatureDonut2, WpfPlot temperatureDonut3, List<TemperatureData> datas, TextBlock donut1Value, TextBlock donut2Value, TextBlock donut3Value, Graph graph)
         {


### PR DESCRIPTION
c:/Windows/Media/ 폴더가 윈도우 운영체제에 기본적으로 있는거 같아서
그 폴더 내의 파일을 사용해 릴리즈해서 exe파일을 실행하니 제 컴퓨터 환경에서는 경고음이 잘 되었습니다.